### PR TITLE
Support "SpaceAfter=No" for Untokenized Text

### DIFF
--- a/spacy_conll/__init__.py
+++ b/spacy_conll/__init__.py
@@ -127,7 +127,7 @@ class ConllFormatter:
                 head_idx,
                 word.dep_,
                 '_',
-                '_'
+                '_' if word.whitespace_ else 'SpaceAfter=No'
             )
 
             token_conll_d = dict(zip(self._field_names.values(), token_conll))


### PR DESCRIPTION
Support "SpaceAfter=No" for [Untokenized Text](https://universaldependencies.org/format.html#untokenized-text)